### PR TITLE
Upgrade from Java 11 to Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
     </issueManagement>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <minimalJavaBuildVersion>${maven.compiler.source}</minimalJavaBuildVersion>
 
         <jakarta.atinject-api.version>2.0.1</jakarta.atinject-api.version>
@@ -394,8 +394,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -654,7 +654,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>11</version>
+                                    <version>17</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -668,7 +668,7 @@
                 <version>${maven-javadoc.version}</version>
                 <configuration>
                     <quiet>true</quiet>
-                    <source>11</source>
+                    <source>17</source>
                     <doclint>none</doclint>
                 </configuration>
             </plugin>
@@ -701,7 +701,7 @@
                 <version>${maven-javadoc.version}</version>
                 <configuration>
                     <quiet>true</quiet>
-                    <source>11</source>
+                    <source>17</source>
                     <doclint>none</doclint>
                 </configuration>
                 <reportSets>
@@ -929,7 +929,7 @@
                         <artifactId>maven-pmd-plugin</artifactId>
                         <version>3.25.0</version>
                         <configuration>
-                            <targetJdk>11</targetJdk>
+                            <targetJdk>17</targetJdk>
 <!--
                             <rulesets>
                                 <ruleset>


### PR DESCRIPTION
- Update maven.compiler.source and maven.compiler.target from 11 to 17
- Update GitHub Actions workflow to use JDK 17 instead of JDK 11
- Update maven-enforcer-plugin Java version requirement to 17
- Update maven-javadoc-plugin source version to 17
- Update maven-pmd-plugin targetJdk to 17
- Fix maven-compiler-plugin target version consistency

All changes tested with successful compilation using Java 17.